### PR TITLE
fix getting filename from args

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -60,7 +60,7 @@ function resolveFile(cwd: string, fileName: string): [string, string] {
 }
 
 async function run(cwd: string, args: string[], text: string): Promise<string> {
-  const fileName = args[0];
+  const fileName = args[0] === "--no-color" ? args[1] : args[0];
   const [cacheKey, fullPath] = resolveFile(cwd, fileName);
   const options = await resolveConfig(cacheKey, fullPath);
   return format(text, options);


### PR DESCRIPTION
core_d sometimes prepends `--no-color` to the arg list. Took me quite some time to debug this, and strikes me as quite odd? Perhaps it's a remnant from eslint_d that carried over to core_d?

See https://github.com/mantoni/core_d.js/blob/bfe1f7c5d5211f006e13217e8f436f507a5da450/lib/client.js#L53-L55