### PR TITLE
let prettier infer parser by providing filename

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -7,17 +7,10 @@ import { Options, format } from "prettier";
 
 const configCache = new LRU({ max: 20, maxAge: 60000 });
 
-function withParser(options: Options | null, filepath: string): Options {
-  return {
-    ...options,
-    filepath,
-  };
-}
-
-async function resolveConfig(cwd: string, filePath: string): Promise<Options> {
+async function resolveConfig(cwd: string, filepath: string): Promise<Options> {
   let v = configCache.get<string, Options>(cwd);
   if (!v) {
-    v = await prettier.resolveConfig(filePath, {
+    v = await prettier.resolveConfig(filepath, {
       editorconfig: true,
       useCache: false,
     });
@@ -25,7 +18,10 @@ async function resolveConfig(cwd: string, filePath: string): Promise<Options> {
       configCache.set(cwd, v);
     }
   }
-  return withParser(v, filePath);
+  return {
+    ...v,
+    filepath,
+  };
 }
 
 function resolveFile(cwd: string, fileName: string): [string, string] {

--- a/src/service.ts
+++ b/src/service.ts
@@ -10,7 +10,7 @@ const configCache = new LRU({ max: 20, maxAge: 60000 });
 function withParser(options: Options | null, filepath: string): Options {
   return {
     ...options,
-    filepath
+    filepath,
   };
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -3,38 +3,14 @@ process.env.FORCE_COLOR = "0";
 import LRU from "nanolru";
 import path from "path";
 import prettier from "prettier";
-import { BuiltInParserName, Options, format } from "prettier";
+import { Options, format } from "prettier";
 
 const configCache = new LRU({ max: 20, maxAge: 60000 });
 
-const getParserName = (ext: string): BuiltInParserName => {
-  switch (ext) {
-    case ".tsx":
-    case ".ts":
-      return "typescript";
-    case ".css":
-    case ".scss":
-      return "css";
-    case ".html":
-      return "html";
-    case ".json":
-      return "json";
-    case ".yml":
-    case ".yaml":
-      return "yaml";
-    case ".md":
-    case ".markdown":
-    case ".mkd":
-      return "markdown";
-    default:
-      return "babel";
-  }
-};
-
-function withParser(options: Options | null, filePath: string): Options {
+function withParser(options: Options | null, filepath: string): Options {
   return {
     ...options,
-    parser: getParserName(path.extname(filePath)),
+    filepath
   };
 }
 


### PR DESCRIPTION
I'm struggling to use this with some filetypes, such as `.graphql`. Is there any reason to provide the parser in here, instead of letting Prettier do it?