### PR TITLE
Handle prettier formatting errors

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -45,5 +45,7 @@ export function invoke(
   _mtime: number,
   cb: (_err?: string, _resp?: string) => void
 ): void {
-  run(cwd, args, text).then((resp) => void cb(undefined, resp));
+  run(cwd, args, text)
+    .then((resp) => void cb(undefined, resp))
+    .catch((error) => void cb(error));
 }


### PR DESCRIPTION
Prevents the service from hanging upon syntax errors.

Fixes #163

## Verification

To verify that it indeed works, you can do the following:

```sh
echo "export }" > test.ts
cat test.ts | prettierd test.ts     # should report the error, and the command exit code should be 1
echo "export {}" > test.ts
cat test.ts | prettierd test.ts     # works fine
```