### PR TITLE
use XDG_CONFIG_HOME for CORE_D_DOTFILE if available

### DIFF
--- a/bin/prettierd.js
+++ b/bin/prettierd.js
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
 
+const path = require("path");
+const fs = require("fs");
+
 process.env.CORE_D_TITLE = "prettierd";
 process.env.CORE_D_DOTFILE = ".prettierd";
 process.env.CORE_D_SERVICE = require.resolve("../dist/service");
+
+if (process.env.HOME && process.env.XDG_CONFIG_HOME) {
+  const confDir = path.join(
+    process.env.XDG_CONFIG_HOME,
+    process.env.CORE_D_TITLE
+  );
+  fs.mkdirSync(confDir, { recursive: true });
+
+  const confPath = path.join(confDir, process.env.CORE_D_TITLE);
+  process.env.CORE_D_DOTFILE = path.relative(process.env.HOME, confPath);
+}
 
 const { main } = require("../dist/main");
 


### PR DESCRIPTION
hi, I noticed prettierd was making a `.prettierd` file in my home directory - where as I like when programs use [XDG_CONFIG_HOME](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)

eg, on my system's env I have
`HOME=/home/senan`
`XDG_CONFIG_HOME=/home/senan/.config`

so this PR asks core d to use `.config/prettierd/prettierd` (it seems to expect a path relative to HOME), if available the variable is set, and makes the directory

thanks!