### PR TITLE
fix: store dotfile in core_d data dir

### DIFF
--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -1,8 +1,6 @@
 import fs from "fs";
-import path from "path";
 import { promisify } from "util";
 
-const mkdir = promisify(fs.mkdir);
 const readFile = promisify(fs.readFile);
 
 async function main(cmdOrFilename: string): Promise<void> {

--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -5,28 +5,12 @@ import { promisify } from "util";
 const mkdir = promisify(fs.mkdir);
 const readFile = promisify(fs.readFile);
 
-async function getDotfile(title: string): Promise<string> {
-  if (process.env.CORE_D_DOTFILE) {
-    return process.env.CORE_D_DOTFILE;
-  }
-
-  if (process.env.HOME && process.env.XDG_CONFIG_HOME) {
-    const confDir = path.join(process.env.XDG_CONFIG_HOME, title);
-    await mkdir(confDir, { recursive: true });
-
-    const confPath = path.join(confDir, title);
-    return path.relative(process.env.HOME, confPath);
-  }
-
-  return ".prettierd";
-}
-
 async function main(cmdOrFilename: string): Promise<void> {
   const title = "prettierd";
 
   process.env.CORE_D_TITLE = title;
   process.env.CORE_D_SERVICE = require.resolve("./service");
-  process.env.CORE_D_DOTFILE = await getDotfile(title);
+  process.env.CORE_D_DOTFILE = `.${title}`;
 
   const core_d = require("core_d");
 


### PR DESCRIPTION
Since https://github.com/mantoni/core_d.js/pull/14, core_d prefixes `$XDG_RUNTIME_DIR || $HOME` as the dir to store the dotfile. prettierd sets its dotfile as `$XDG_CONFIG_HOME/prettierd/prettierd`, so core_d's full [`data_file` path](https://github.com/mantoni/core_d.js/blob/b83890ed394a65093230d0bcd30bbe003ae4325e/lib/portfile.js#L8) gets resolved as `/run/user/1000/.config/prettierd/prettierd` for me.

As core_d doesn't create intermediary dirs, it fails to start (which should probably be fixed in core_d either way).

However, as `.config` under `$XDG_RUNTIME_DIR` isn't really XDG compliant, follow [eslint_d's behaviour](https://github.com/mantoni/eslint_d.js/blob/29a524a4788b892822652db79a93d546af22e31b/bin/eslint_d.js#L24) and just set `$CORE_D_DOTFILE` as a file (per the env's name).

Closes #183.
