### PR TITLE
feat: Bump @types/prettier to 2.4.0 for pluginSearchDirs typedef support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/fsouza/prettierd#readme",
   "devDependencies": {
     "@types/node": "^16.7.8",
-    "@types/prettier": "^2.1.6",
+    "@types/prettier": "^2.4.0",
     "doctoc": "^2.0.1",
     "typescript": "^4.1.3"
   },

--- a/src/service.ts
+++ b/src/service.ts
@@ -157,7 +157,6 @@ async function run(cwd: string, args: string[], text: string): Promise<string> {
 
   return prettier.format(text, {
     ...options,
-    // @ts-ignore: pluginSearchDirs is not declared in the prettier interface :(
     pluginSearchDirs: await pluginSearchDirs(cwd),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.6.tgz#040a64d7faf9e5d9e940357125f0963012e66f04"
   integrity sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==
 
-"@types/prettier@^2.1.6":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
-  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
+"@types/prettier@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.npmmirror.com/@types/prettier/download/@types/prettier-2.4.0.tgz#900b13362610ccd3570fb6eefb911a6732973d00"
+  integrity sha1-kAsTNiYQzNNXD7bu+5EaZzKXPQA=
 
 anchor-markdown-header@~0.5.7:
   version "0.5.7"


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55873/commits/f53059a3e2a8d23b59b624d38b5df9dee4206181