### PR TITLE
feat: support ignoring files with .prettierignore

### DIFF
--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -37,10 +37,7 @@ async function main(args: string[]): Promise<void> {
     return;
   }
 
-  core_d.invoke(
-    [cmdOrFilename],
-    await readFile(process.stdin.fd, { encoding: "utf-8" })
-  );
+  core_d.invoke(args, await readFile(process.stdin.fd, { encoding: "utf-8" }));
 }
 
 main(process.argv.slice(2)).catch((err) => {


### PR DESCRIPTION
Add support for ignoring files specified in `.prettierignore`.

The path to the ignore file can be customized by passing in the `--ignore-path` option, similarly to prettier CLI. See https://prettier.io/docs/en/cli.html#--ignore-path for more information.

This commit adds a bit more robust CLI arguments parsing. There will be more explicit errors when the path to the file to format is not provided (prettier expects it anyway and would throw otherwise) and when the `--ignore-path` flag is passed, but its argument is not.

Prettier's public `getFileInfo` API is used to reuse the same logic that Prettier uses for determining whether the file should be ignored or not. See https://prettier.io/docs/en/api.html#prettiergetfileinfofilepath--options

The performance does not seem to have degraded. I did not notice slowdowns with the extra call to `getFileInfo`.

## Example


<details>
<summary>An example that shows that this feature is working correctly</summary>

I have used this repo, since it has `package.json` already in `.prettierignore`. I added a few extra lines to `package.json`:

![image](https://user-images.githubusercontent.com/889383/138588031-2aca21dd-c7f0-484c-8a70-c40772314372.png)

With this PR, the extra lines are not removed (which would happen if the files was formatted), since the file is ignored:
![image](https://user-images.githubusercontent.com/889383/138588076-96601852-a183-41b1-9204-151024233fef.png)

Changing the `--ignore-path` to `.gitignore` (which does not include `package.json`) means that the file is formatted, which is expected (the extra lines are gone):

![image](https://user-images.githubusercontent.com/889383/138588137-91143033-ab4b-481f-b2fd-e13f89e96bc7.png)

</details>