### PR TITLE
feat: new help menu

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -5,40 +5,40 @@ interface Command {
 
 const commands: Command[] = [
   {
-    command: '--help',
-    description: 'Show CLI usage.',
+    command: "--help",
+    description: "Show CLI usage.",
   },
   {
-    command: '--version\t',
-    description: 'Print prettierd version.',
+    command: "--version\t",
+    description: "Print prettierd version.",
   },
   {
-    command: '--ignore-path <path>',
-    description: 'Path to a file with patterns describing files to ignore.',
+    command: "--ignore-path <path>",
+    description: "Path to a file with patterns describing files to ignore.",
   },
   {
-    command: '--no-color\t',
-    description: 'Do not colorize error messages.',
+    command: "--no-color\t",
+    description: "Do not colorize error messages.",
   },
   {
-    command: 'start\t\t',
-    description: 'Start the prettierd.',
+    command: "start\t\t",
+    description: "Start the prettierd.",
   },
   {
-    command: 'stop\t\t',
-    description: 'Stop the prettierd.',
+    command: "stop\t\t",
+    description: "Stop the prettierd.",
   },
   {
-    command: 'restart\t',
-    description: 'Restart the prettierd.',
+    command: "restart\t",
+    description: "Restart the prettierd.",
   },
   {
-    command: 'status\t\t',
-    description: 'Get the prettierd status.',
+    command: "status\t\t",
+    description: "Get the prettierd status.",
   },
   {
-    command: 'invoke\t\t',
-    description: 'Invoke the prettierd.',
+    command: "invoke\t\t",
+    description: "Invoke the prettierd.",
   },
 ];
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,49 @@
+interface iCommands {
+  command: string;
+  description: string;
+}
+
+const commands: iCommands[] = [
+  {
+    command: "--help",
+    description: "Show CLI usage.",
+  },
+  {
+    command: "--version\t",
+    description: "Print prettierd version.",
+  },
+  {
+    command: "--ignore-path <path>",
+    description: "Path to a file with patterns describing files to ignore.",
+  },
+  {
+    command: "--no-color\t",
+    description: "Do not colorize error messages.",
+  },
+  {
+    command: "start\t",
+    description: "Start the prettierd.",
+  },
+  {
+    command: "stop\t",
+    description: "Stop the prettierd.",
+  },
+  {
+    command: "restart\t",
+    description: "Restart the prettierd.",
+  },
+  {
+    command: "status\t",
+    description: "Get the prettierd status.",
+  },
+  {
+    command: "invoke\t",
+    description: "Invoke the prettierd.",
+  },
+];
+
+export function displayHelp() {
+  for (let i = 0, length = commands.length; i < length; i++) {
+    console.log(` ${commands[i].command}\t${commands[i].description}\n`);
+  }
+}

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,44 +1,44 @@
-interface iCommands {
+interface Command {
   command: string;
   description: string;
 }
 
-const commands: iCommands[] = [
+const commands: Command[] = [
   {
-    command: "--help",
-    description: "Show CLI usage.",
+    command: '--help',
+    description: 'Show CLI usage.',
   },
   {
-    command: "--version\t",
-    description: "Print prettierd version.",
+    command: '--version\t',
+    description: 'Print prettierd version.',
   },
   {
-    command: "--ignore-path <path>",
-    description: "Path to a file with patterns describing files to ignore.",
+    command: '--ignore-path <path>',
+    description: 'Path to a file with patterns describing files to ignore.',
   },
   {
-    command: "--no-color\t",
-    description: "Do not colorize error messages.",
+    command: '--no-color\t',
+    description: 'Do not colorize error messages.',
   },
   {
-    command: "start\t",
-    description: "Start the prettierd.",
+    command: 'start\t\t',
+    description: 'Start the prettierd.',
   },
   {
-    command: "stop\t",
-    description: "Stop the prettierd.",
+    command: 'stop\t\t',
+    description: 'Stop the prettierd.',
   },
   {
-    command: "restart\t",
-    description: "Restart the prettierd.",
+    command: 'restart\t',
+    description: 'Restart the prettierd.',
   },
   {
-    command: "status\t",
-    description: "Get the prettierd status.",
+    command: 'status\t\t',
+    description: 'Get the prettierd status.',
   },
   {
-    command: "invoke\t",
-    description: "Invoke the prettierd.",
+    command: 'invoke\t\t',
+    description: 'Invoke the prettierd.',
   },
 ];
 

--- a/src/args.ts
+++ b/src/args.ts
@@ -3,6 +3,13 @@ interface Command {
   description: string;
 }
 
+/**
+ * Note: today this is an array that is only used to display the help menu,
+ * but the plan is to improve later to be an array where commands will be defined.
+ *
+ * TODO: improve the way of displaying the help menu so that no longer need all the "\t's"
+ * (as today it just strings the (\t) is used to keep all descriptions aligned.)
+ */
 const commands: Command[] = [
   {
     command: "--help",

--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -2,17 +2,23 @@ import fs from "fs";
 import { promisify } from "util";
 
 // @ts-ignore
-const { version } = require("../package.json");
+import { version } from "../package.json";
+import { displayHelp } from "./args";
 
 const readFile = promisify(fs.readFile);
 const validCommands = ["restart", "start", "status", "stop"];
 
-type Action = "PRINT_VERSION" | "INVOKE_CORE_D";
+type Action = "PRINT_VERSION" | "INVOKE_CORE_D" | "PRINT_HELP";
 
 function processArgs(args: string[]): [Action, string] {
   if (args.find((arg) => arg === "--version")) {
     return ["PRINT_VERSION", ""];
   }
+
+  if (args.find((arg) => arg === "--help")) {
+    return ["PRINT_HELP", ""];
+  }
+
   return ["INVOKE_CORE_D", args[0]];
 }
 
@@ -21,6 +27,9 @@ async function main(args: string[]): Promise<void> {
 
   if (action === "PRINT_VERSION") {
     console.log(`prettierd ${version}`);
+    return;
+  } else if (action === "PRINT_HELP") {
+    displayHelp();
     return;
   }
 


### PR DESCRIPTION
since the quantity of command-line arguments is increasing it is a good idea to create a help menu. fix #278

Also with this new addition, can be possible to set the commands in this array instead of switch-case statements. (can be a good addition in the future, but for now, it is used only for the help menu)