### PR TITLE
github/workflows/main: add Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,7 @@ jobs:
         os:
           - ubuntu
           - macos
+          - windows
         node-version:
           - "14.x"
           - "16.x"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "prepare": "yarn build",
     "build": "tsc -b",
-    "run": "bin/prettierd",
-    "start": "bin/prettierd start",
+    "run": "node bin/prettierd",
+    "start": "node bin/prettierd start",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write ."
   },


### PR DESCRIPTION
We're running into some Windows-only bug, let's start by having Windows
to CI. This shouldn't fail, as I don't have a test reproducing the bug
just yet.