### PR TITLE
service: fix PRETTIERD_DEFAULT_CONFIG

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -139,7 +139,7 @@ async function resolveConfigNoCache(
     config = await tryToResolveConfigFromEnvironmentValue(
       prettier,
       editorconfig,
-      env.PRETTIERD_LOCAL_PRETTIER_ONLY
+      env.PRETTIERD_DEFAULT_CONFIG
     );
   }
 


### PR DESCRIPTION
This was an accidental change as part of unifying environment variables from the client and from the server.

Fix #418.