### PR TITLE
Fix handling of flags and file config

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -320,11 +320,9 @@ async function run(
   });
 
   const options: Record<string, unknown> =
-    configPrecedence === "cli-override"
-      ? { ...fileOptions, ...cliOptions }
-      : configPrecedence === "file-override"
+    configPrecedence === "file-override" || configPrecedence === "prefer-file"
       ? { ...cliOptions, ...fileOptions }
-      : fileOptions || cliOptions;
+      : { ...fileOptions, ...cliOptions };
 
   return prettier.format(text, {
     ...options,


### PR DESCRIPTION
We'll prefer the file only if we're told to do so, otherwise we CLI options override whatever is defined in the config file.