### PR TITLE
service: fix the handling of `prefer-file`

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -317,7 +317,9 @@ async function run(
   });
 
   const options: Record<string, unknown> =
-    configPrecedence === "file-override" || configPrecedence === "prefer-file"
+    configPrecedence === "prefer-file" && fileOptions !== null
+      ? fileOptions
+      : configPrecedence === "file-override"
       ? { ...cliOptions, ...fileOptions }
       : { ...fileOptions, ...cliOptions };
 


### PR DESCRIPTION
According to the docs, when `prefer-file` is set and we can load configuration from a file, we should use that.

The nested ternary is messy, but we can improve that later.

Closes #557.