### PR TITLE
Use `$XDG_RUNTIME_DIR/prettierd` when it's present

### DIFF
--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -48,10 +48,9 @@ function printDebugInfo(debugInfo: DebugInfo): void {
 
 function getRuntimeDir(): string {
   const baseDir = process.env.XDG_RUNTIME_DIR ?? os.homedir();
-  const basename = path.basename(baseDir);
 
-  return basename === "prettierd" || basename === ".prettierd"
-    ? baseDir
+  return process.env.XDG_RUNTIME_DIR
+    ? path.join(baseDir, "prettierd")
     : path.join(baseDir, ".prettierd");
 }
 


### PR DESCRIPTION
Related issues: #567
So, I recently updated my prettierd to the newest version. I noticed that it didn't respect my `.editorconfig`.
After some investigation using `git bisect`, I've identified the problematic commit as 4515d07

```ts
function getRuntimeDir(): string {
  const baseDir = process.env.XDG_RUNTIME_DIR ?? os.homedir();
  //    ^^ my XDG_RUNTIME_DIR is set to `/run/user/1000` 
  const basename = path.basename(baseDir);
  //    ^^ here, the value of basename variable  will always be the `id` of the current user, for me it's 1000
  return basename === "prettierd" || basename === ".prettierd"
    ? baseDir
    : path.join(baseDir, ".prettierd");
   
}
```
What I know is, the function is supposed to return `$XDG_RUNTIME_DIR/prettierd` instead of `$XDG_RUNTIME_DIR/.prettierd`. 

Please note that I don't know much about this project.
If there are any additional changes or considerations I should keep in mind, please let me know. 

Thank you.