### PR TITLE
add Sublime Text integration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ package, you can set the environment variable `PRETTIERD_LOCAL_PRETTIER_ONLY`
 
 ## Editor integration
 
+### Vim / Neovim
+
 I use this directly with neovim's LSP client, via
 [efm-langserver](https://github.com/mattn/efm-langserver):
 
@@ -98,7 +100,7 @@ local prettier = {
 }
 ```
 
-Alternatively, one can use
+Alternatively, you can use
 [prettierme](https://github.com/ruyadorno/prettierme) to integrate directly
 with other editors.
 
@@ -125,6 +127,35 @@ require('formatter').setup({
   }
 })
 ```
+
+### Sublime Text
+
+#### Prettierd Format
+
+You can use [Prettierd Format](https://packagecontrol.io/packages/Prettierd%20Format) to format your files with prettierd. After installation, it enables format-on-save for any file supported by Prettier by default.
+
+#### Fmt
+
+Alternatively, if you're looking for something more advanced that supports multiple formatters, you can use [Fmt](https://packagecontrol.io/packages/Fmt) and configure prettierd for each language you wish to format:
+
+```json
+{
+  "rules": [
+    {
+      "selector": "source.ts",
+      "cmd": ["prettierd", "--stdin-filepath", "$file"],
+      "format_on_save": true
+    },
+    {
+      "selector": "source.json",
+      // ...
+    },
+    // ...
+  ]
+}
+```
+
+### Other editors
 
 I don't know much about other editors, but feel free to send a pull requests on
 instructions.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ prettier configuration. For example, to use the Ruby plugin, install
 [`@prettier/plugin-ruby`](https://www.npmjs.com/package/@prettier/plugin-ruby)
 and add it to your configuration:
 
-```json5
+```json
 {
   // ... other settings
   "plugins": ["@prettier/plugin-ruby"]
@@ -138,7 +138,7 @@ You can use [Prettierd Format](https://packagecontrol.io/packages/Prettierd%20Fo
 
 Alternatively, if you're looking for something more advanced that supports multiple formatters, you can use [Fmt](https://packagecontrol.io/packages/Fmt) and configure prettierd for each language scope you wish to format:
 
-```json5
+```json
 {
   "rules": [
     {
@@ -147,9 +147,9 @@ Alternatively, if you're looking for something more advanced that supports multi
       "format_on_save": true
     },
     {
-      "selector": "source.json",
+      "selector": "source.json"
       // ...
-    },
+    }
     // ...
   ]
 }

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ prettier configuration. For example, to use the Ruby plugin, install
 [`@prettier/plugin-ruby`](https://www.npmjs.com/package/@prettier/plugin-ruby)
 and add it to your configuration:
 
-```json
+```json5
 {
-  ... other settings
+  // ... other settings
   "plugins": ["@prettier/plugin-ruby"]
 }
 ```
@@ -136,9 +136,9 @@ You can use [Prettierd Format](https://packagecontrol.io/packages/Prettierd%20Fo
 
 #### Fmt
 
-Alternatively, if you're looking for something more advanced that supports multiple formatters, you can use [Fmt](https://packagecontrol.io/packages/Fmt) and configure prettierd for each language you wish to format:
+Alternatively, if you're looking for something more advanced that supports multiple formatters, you can use [Fmt](https://packagecontrol.io/packages/Fmt) and configure prettierd for each language scope you wish to format:
 
-```json
+```json5
 {
   "rules": [
     {


### PR DESCRIPTION
Hi @fsouza, first of all, thank you for prettierd. This PR adds to the readme two different ways to integrate Sublime Text with it.

The first solution is a package I published, the second is another great tool which can be used to configure a formatter for each Sublime language scope. 

I allowed myself to change the json code blocks syntax highlight to json5 to avoid marking comments as invalid and to correct a little typo.