### PR TITLE
Add configuration example for Zed editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,13 @@ Alternatively, if you're looking for something more advanced that supports multi
 
 ### Zed
 
-To use Prettierd with Zed, you need to configure the `language_overrides` adding a `format_on_save` command for each of the languages you wish to be handling. Example configuration:
+To use Prettierd with Zed, you need to configure the `language_overrides` adding a `format_on_save` command for each of the languages you wish to be handling.
+
+> ![NOTE]
+> Configuration below assumes you have installed `prettierd` and gives an example of its path from Homebrew installation. You can check path on your system by running `which prettierd`.
+
+Example configuration:
+
 ```json
 {
   "language_overrides": {

--- a/README.md
+++ b/README.md
@@ -155,6 +155,29 @@ Alternatively, if you're looking for something more advanced that supports multi
 }
 ```
 
+### Zed
+
+To use Prettierd with Zed, you need to configure the `language_overrides` adding a `format_on_save` command for each of the languages you wish to be handling. Example configuration:
+```json
+{
+  "language_overrides": {
+    "TypeScript": {
+      "format_on_save": {
+        "external": {
+          "command": "/opt/homebrew/bin/prettierd",
+          "arguments": [
+            "--stdin-filepath",
+            "{buffer_path}"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+Saveyour configuration file, and provided you've installed and set the correct path to `prettierd` program, Zed will start formatting your files on save action.
+
 ### Other editors
 
 I don't know much about other editors, but feel free to send a pull requests on

--- a/README.md
+++ b/README.md
@@ -171,10 +171,7 @@ Example configuration:
       "format_on_save": {
         "external": {
           "command": "/opt/homebrew/bin/prettierd",
-          "arguments": [
-            "--stdin-filepath",
-            "{buffer_path}"
-          ]
+          "arguments": ["--stdin-filepath", "{buffer_path}"]
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Alternatively, if you're looking for something more advanced that supports multi
 
 To use Prettierd with Zed, you need to configure the `language_overrides` adding a `format_on_save` command for each of the languages you wish to be handling.
 
-> ![NOTE]
+> [!NOTE]
 > Configuration below assumes you have installed `prettierd` and gives an example of its path from Homebrew installation. You can check path on your system by running `which prettierd`.
 
 Example configuration:


### PR DESCRIPTION
This adds a configuration example for a relatively new but already highly popular editor, [Zed](https://zed.dev).