### PR TITLE
service: fix handling of --option <value>

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -153,8 +153,26 @@ function parseCLIArguments(args: string[]): [CLIArguments, string, CliOptions] {
           parsedArguments.ignorePath = nextArg.value;
           break;
         }
+        case "--stdin-filepath": {
+          const nextArg = argsIterator.next();
+          if (nextArg.done) {
+            throw new Error("--stdin-filepath option expects a file path");
+          }
+
+          fileName = nextArg.value;
+          break;
+        }
         default: {
-          optionArgs.push(arg);
+          if (arg.includes("=")) {
+            optionArgs.push(arg);
+          } else {
+            const nextArg = argsIterator.next();
+            if (nextArg.done) {
+              throw new Error(`--${arg} expects a value`);
+            }
+
+            optionArgs.push(`${arg}=${nextArg.value}`);
+          }
         }
       }
     } else {


### PR DESCRIPTION
Running `prettier --help` shows options with their values separated with spaces.

Running `prettierd` with the options formatted as such doesn't work, but prettier doesn't differentiate between `--opt=val` and `--opt val`. Unfortunately my editor setup uses the space variety and isn't easy to change as it affects other formatting tools as well.

A better solution would be to somehow import prettier's option handling code, but I thought that might be a bit too much for this.

before:
```
bin/prettierd --tab-width 2 --stdin-filepath src/service.ts < src/service.ts # ❌
bin/prettierd --tab-width=2 --stdin-filepath src/service.ts < src/service.ts # ✅
bin/prettierd --stdin-filepath src/service.ts < src/service.ts # ✅
bin/prettierd src/service.ts < src/service.ts # ✅
```

after:

```
bin/prettierd --tab-width=2 --stdin-filepath src/service.ts < src/service.ts # ✅
bin/prettierd --tab-width 2 --stdin-filepath src/service.ts < src/service.ts # ✅
bin/prettierd --stdin-filepath src/service.ts < src/service.ts # ✅
bin/prettierd src/service.ts < src/service.ts # ✅
```