### PR TITLE
fix: missing space typo on line 182 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Example configuration:
 }
 ```
 
-Saveyour configuration file, and provided you've installed and set the correct path to `prettierd` program, Zed will start formatting your files on save action.
+Save your configuration file, and provided you've installed and set the correct path to `prettierd` program, Zed will start formatting your files on save action.
 
 ### Other editors
 


### PR DESCRIPTION
Hey! I found a missing space in README.md and went ahead to fix it.