### PR TITLE
documentation: fix args = ... causing errors on specific file paths in nvim/vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ require('formatter').setup({
        function()
           return {
             exe = "prettierd",
-            args = {vim.api.nvim_buf_get_name(0)},
+            args = {"\"" .. tostring(vim.api.nvim_buf_get_name(0)).."\""},
             stdin = true
           }
         end

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ require('formatter').setup({
        function()
           return {
             exe = "prettierd",
-            args = {"\"" .. tostring(vim.api.nvim_buf_get_name(0)).."\""},
+            args = {"\"" .. vim.api.nvim_buf_get_name(0) .."\""},
             stdin = true
           }
         end


### PR DESCRIPTION
The following code will fail when formatting file paths that have characters that need to be escaped.
ex.  XXX/routes/[locale]/index.js

```lua
require('formatter').setup({
  logging = false,
  filetype = {
    javascript = {
        -- prettierd
       function()
          return {
            exe = "prettierd",
            args = {vim.api.nvim_buf_get_name(0)}, << This line
            stdin = true
          }
        end
    },
    -- other formatters ...
  }
})
````

The proposed documentation change resolves this issue by passing a string to prettierd instead.