### PR TITLE
Fallback to TMPDIR if XDG_RUNTIME_DIR is not set

### DIFF
--- a/src/prettierd.ts
+++ b/src/prettierd.ts
@@ -46,7 +46,8 @@ function printDebugInfo(debugInfo: DebugInfo): void {
 }
 
 function getRuntimeDir(): string {
-  const baseDir = process.env.XDG_RUNTIME_DIR ?? os.homedir();
+  const baseDir =
+    process.env.XDG_RUNTIME_DIR ?? process.env.TMPDIR ?? os.homedir();
   const basename = path.basename(baseDir);
 
   return basename === "prettierd" || basename === ".prettierd"


### PR DESCRIPTION
On most macOS setups, `XDG_RUNTIME_DIR` won't exist, but rather than creating something in the home directory, we can fall back to `TMPDIR`. Then, users won't have to find ways to set `XDG_RUNTIME_DIR` manually if they want to keep their home directory clean. Setting it manually can have some undesirable consequences, as outlined in the issue.

This approach is intended to keep the existing behaviour for users who have `XDG_RUNTIME_DIR` set. If they don't, and have `TMPDIR` set, then their `runtimeDir` will change. Otherwise, it will do nothing for them.

There may be users with neither `XDG_RUNTIME_DIR` nor `TMPDIR` set. I think we will be happy for them to make another PR if they don't want the `runtimeDir` in their home directory.

Fixes: #833