### PR TITLE
docs: avoid highlighting json comments as red on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ prettier configuration. For example, to use the Ruby plugin, install
 [`@prettier/plugin-ruby`](https://www.npmjs.com/package/@prettier/plugin-ruby)
 and add it to your configuration:
 
-```json
+```jsonc
 {
   // ... other settings
-  "plugins": ["@prettier/plugin-ruby"]
+  "plugins": ["@prettier/plugin-ruby"],
 }
 ```
 
@@ -138,20 +138,20 @@ You can use [Prettierd Format](https://packagecontrol.io/packages/Prettierd%20Fo
 
 Alternatively, if you're looking for something more advanced that supports multiple formatters, you can use [Fmt](https://packagecontrol.io/packages/Fmt) and configure prettierd for each language scope you wish to format:
 
-```json
+```jsonc
 {
   "rules": [
     {
       "selector": "source.ts",
       "cmd": ["prettierd", "--stdin-filepath", "$file"],
-      "format_on_save": true
+      "format_on_save": true,
     },
     {
-      "selector": "source.json"
+      "selector": "source.json",
       // ...
-    }
+    },
     // ...
-  ]
+  ],
 }
 ```
 


### PR DESCRIPTION
Even though comments are useful in the README, JSON does not allow comments at all. For this reason, the comments are highlighted as a red, "errorish" color when viewed on GitHub.

This changes the codeblocks to use `jsonc` (JSON with comments) syntax, which avoids the red colorization.

Before:

<img width="960" height="318" alt="image" src="https://github.com/user-attachments/assets/57ffc406-488c-4375-8f04-cae77b1fefb8" />

After:

<img width="1162" height="320" alt="image" src="https://github.com/user-attachments/assets/ed7282ba-2c78-49f5-ac89-6217ce699663" />
