### PR TITLE
chore: run `yarn install --frozen-lockfile` with Yarn 1.22.22

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -41,5 +41,6 @@
   "optionalDependencies": {
     "@babel/parser": "^7.28.0",
     "@typescript-eslint/typescript-estree": "^8.37.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }


### PR DESCRIPTION
The version of yarn to be used was not specified, but yarn wants to add it to the `package.json` file when the install command is run.

Also ran `corepack use yarn@1` to get access to Yarn 1.22.22