### PR TITLE
chore(deps): remove @types/prettier stub types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/fsouza/prettierd",
   "devDependencies": {
     "@types/node": "^24.0.10",
-    "@types/prettier": "^3.0.0",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,13 +55,6 @@
   dependencies:
     undici-types "~7.8.0"
 
-"@types/prettier@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-3.0.0.tgz#e9bc8160230d3a461dab5c5b41cceef1ef723057"
-  integrity sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==
-  dependencies:
-    prettier "*"
-
 "@typescript-eslint/project-service@8.36.0":
   version "8.36.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.36.0.tgz#0c4acdcbe56476a43cdabaac1f08819424a379fd"
@@ -227,7 +220,7 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-prettier@*, prettier@^3.6.2:
+prettier@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==


### PR DESCRIPTION
The following notice is displayed when running
`yarn install --frozen-lockfile`:

```sh
➤ YN0000: ┌ Resolution step
➤ YN0061: │ @types/prettier@npm:3.0.0 is deprecated: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.
```

It looks like the types for prettier are not needed anymore -> remove them.