### PR TITLE
ci: drop EOL Node 20, add Node 26

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,9 @@ jobs:
           - macos
           - windows
         node-version:
-          - "20.x"
           - "22.x"
           - "24.x"
+          - "26.x"
 
     name: build
     runs-on: ${{ matrix.os }}-latest

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "url": "https://github.com/fsouza/prettierd/issues"
   },
   "homepage": "https://github.com/fsouza/prettierd",
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "@types/node": "^26.1.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Summary

Node 20 has reached **end-of-life**, so this drops it from the CI build matrix and adds **Node 26** in its place.

The matrix now runs across **Node 22, 24, and 26** on Linux/macOS/Windows.

## Changes

- `.github/workflows/main.yaml`: `node-version` matrix `20.x, 22.x, 24.x` → `22.x, 24.x, 26.x`
- `package.json`: add `"engines": { "node": ">=22" }` so the dropped Node 20 support is declared to consumers (npm warns at install time on older Node), not just enforced in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)