### PR TITLE
changelog: prep v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # prettierd
 
+## v0.29.0
+
+### Changed
+
+- Minimum supported Node.js version is now 22 (dropped support for Node.js 20)
+
+### Updated dependencies
+
+- `prettier` upgraded to `^3.9.5`
+- `@babel/parser` upgraded to `^8.0.4`
+- `@typescript-eslint/typescript-estree` upgraded to `^8.64.0`
+
 ## v0.28.0
 
 ### Updated dependencies


### PR DESCRIPTION
## Summary

Prepares `CHANGELOG.md` for the **v0.29.0** release. Changelog-only — the version bump in `package.json` and the `v0.29.0` tag are handled separately after this merges.

## Changelog entry

Covers everything landed since `v0.28.0`:

- **Changed:** minimum supported Node.js is now 22 (Node 20 dropped, `engines` set to `>=22`)
- **Updated dependencies:** `prettier` `^3.9.5`, `@babel/parser` `^8.0.4`, `@typescript-eslint/typescript-estree` `^8.64.0`

Following existing convention, only shipped/runtime deps are listed (dev-only changes like the TypeScript 7 and `@types/node` bumps are omitted).

## Release steps after merge

1. Bump `package.json` to `0.29.0` and tag `v0.29.0` (e.g. `yarn version --new-version 0.29.0`)
2. Push the tag — `publish.yaml` runs `npm publish` on `v*` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)