### PR TITLE
publish: define empty NODE_AUTH_TOKEN for yarn install

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,5 +21,11 @@ jobs:
           scope: "@fsouza"
 
       - run: yarn install --frozen-lockfile
+        env:
+          # setup-node writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+          # into .npmrc. yarn 1.x eagerly expands that and errors if the var is
+          # unset. We publish via OIDC (no token), so define it empty here — no
+          # auth is needed to install public deps.
+          NODE_AUTH_TOKEN: ""
 
       - run: npm publish --access public


### PR DESCRIPTION
## Problem

The v0.29.0 release run [failed](https://github.com/fsouza/prettierd/actions/runs/30186416937) at `yarn install --frozen-lockfile`:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`actions/setup-node` (with `registry-url`) writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc`. yarn 1.x eagerly expands that reference while normalizing registry config and throws when the var is unset. Since we switched publishing to OIDC (no token secret), `NODE_AUTH_TOKEN` is never defined, so the install step fails before it does any work.

## Fix

Publishing via OIDC needs no token, and installing public deps needs no auth. Define `NODE_AUTH_TOKEN` as empty on the install step so yarn's env expansion succeeds. The `npm publish` step is unchanged and continues to use OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)